### PR TITLE
Remove array caching to prevent always returning miss from memory

### DIFF
--- a/src/CacheAdapter.php
+++ b/src/CacheAdapter.php
@@ -312,22 +312,22 @@ class CacheAdapter implements FilesystemAdapter, ChecksumProvider
         $algo = $config->get('checksum_algo');
         $metadataKey = isset($algo) ? 'checksum_' . $algo : 'checksum';
 
-        $attributeAccessor = function (FileAttributes $fileAttributes) use ($metadataKey) {
+        $attributeAccessor = function (StorageAttributes $storageAttributes) use ($metadataKey) {
             if (\is_a($this->adapter, 'League\Flysystem\AwsS3V3\AwsS3V3Adapter')) {
                 // Special optimization for AWS S3, but won't break if adapter not installed
-                $etag = $fileAttributes->extraMetadata()['ETag'] ?? \null;
+                $etag = $storageAttributes->extraMetadata()['ETag'] ?? \null;
                 if (isset($etag)) {
                     $checksum = trim($etag, '" ');
                 }
             }
 
-            return $checksum ?? $fileAttributes->extraMetadata()[$metadataKey] ?? \null;
+            return $checksum ?? $storageAttributes->extraMetadata()[$metadataKey] ?? \null;
         };
 
         $fileAttributes = $this->getFileAttributes(
             path: $path,
             loader: function () use ($path, $config, $metadataKey) {
-                // This part is "mirrored" from FileSystem class to provide the fallback mechanism 
+                // This part is "mirrored" from FileSystem class to provide the fallback mechanism
                 // and be able to cache the result
                 try {
                     if (!$this->adapter instanceof ChecksumProvider) {

--- a/src/CacheItemsTrait.php
+++ b/src/CacheItemsTrait.php
@@ -12,7 +12,7 @@ use League\Flysystem\FilesystemAdapter;
 
 /**
  * Trait for handling cache items in CacheAdapter
- * 
+ *
  * @property FilesystemAdapter $adapter
  * @property CacheItemPoolInterface $cache
  */
@@ -21,42 +21,21 @@ trait CacheItemsTrait
     const CACHE_KEY_PREFIX = 'flysystem_item_';
     const CACHE_KEY_HASH_SALT = '563ce5132194441b';
 
-    /** @var array<CacheItemInterface> */
-    protected $cacheItems = [];
-
     protected function getCacheItem(string $path): CacheItemInterface
     {
-        if (!isset($this->cacheItems[$path])) {
-            $key = self::getCacheItemKey($path);
+        $key = self::getCacheItemKey($path);
 
-            $this->cacheItems[$path] = $this->cache->getItem($key);
-        }
-
-        return $this->cacheItems[$path];
+        return $this->cache->getItem($key);
     }
 
     protected function saveCacheItem(CacheItemInterface $cacheItem): void
     {
         $this->cache->save($cacheItem);
-
-        /** @var StorageAttributes $storageAttributes */
-        $storageAttributes = $cacheItem->get();
-
-        $path = $storageAttributes->path();
-
-        $this->cacheItems[$path] = $cacheItem;
     }
 
     protected function deleteCacheItem(CacheItemInterface $cacheItem): void
     {
         $this->cache->deleteItem($cacheItem->getKey());
-
-        /** @var StorageAttributes $storageAttributes */
-        $storageAttributes = $cacheItem->get();
-
-        $path = $storageAttributes->path();
-
-        unset($this->cacheItems[$path]);
     }
 
     public static function getCacheItemKey(string $path): string
@@ -76,7 +55,7 @@ trait CacheItemsTrait
     /**
      * Returns a new FileAttributes with all properties from $fileAttributesExtension
      * overriding existing properties from $fileAttributesBase (with the exception of path)
-     * 
+     *
      * For extraMetadata, each individual element in the array is also merged
      */
     protected static function mergeFileAttributes(
@@ -103,7 +82,7 @@ trait CacheItemsTrait
     /**
      * Returns a new DirectoryAttributes with all properties from $directoryAttributesExtension
      * overriding existing properties from $directoryAttributesBase (with the exception of path)
-     * 
+     *
      * For extraMetadata, each individual element in the array is also merged
      */
     protected static function mergeDirectoryAttributes(
@@ -126,7 +105,7 @@ trait CacheItemsTrait
     /**
      * Returns FileAttributes from cache if desired attribute is found,
      * or loads the desired missing attribute from the adapter and merges it with the cached attributes.
-     * 
+     *
      * @param Closure $loader Returns FileAttributes with the desired attribute loaded from adapter
      * @param Closure $attributeAccessor Returns value of desired attribute from cached item
      */

--- a/tests/CacheItemsTrait_Test.php
+++ b/tests/CacheItemsTrait_Test.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace tests\jgivoni\Flysystem\Cache;
+
+use jgivoni\Flysystem\Cache\CacheItemsTrait;
+use League\Flysystem\FileAttributes;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class CacheItemsTrait_Test extends TestCase
+{
+    /**
+     * @test
+     */
+    public function return_hit_after_miss(): void
+    {
+        $adapter = new class {
+            use CacheItemsTrait;
+
+            public function __construct(
+                protected readonly CacheItemPoolInterface $cache = new ArrayAdapter()
+            ) {
+            }
+
+            public function getItem(string $path): CacheItemInterface
+            {
+                return $this->getCacheItem($path);
+            }
+
+            public function saveItem(CacheItemInterface $item): void
+            {
+                $this->saveCacheItem($item);
+            }
+        };
+
+        $path = 'test.txt';
+        $item = $adapter->getItem($path);
+
+        self::assertFalse($item->isHit());
+
+        $item->set(new FileAttributes(
+            path: $path
+        ));
+
+        $adapter->saveItem($item);
+
+        $freshItem = $adapter->getItem($path);
+        self::assertTrue($freshItem->isHit());
+    }
+}

--- a/tests/FileExists_Test.php
+++ b/tests/FileExists_Test.php
@@ -6,7 +6,7 @@ use League\Flysystem\FileAttributes;
 
 class FileExists_Test extends CacheTestCase
 {
-    /** 
+    /**
      * @test
      * @dataProvider dataProvider
      */
@@ -18,7 +18,7 @@ class FileExists_Test extends CacheTestCase
     }
 
     /**
-     * 
+     *
      * @return iterable<array<mixed>>
      */
     public static function dataProvider(): iterable
@@ -30,7 +30,7 @@ class FileExists_Test extends CacheTestCase
         yield 'directory is not a file' => ['cached-directory', false];
     }
 
-    /** 
+    /**
      * @test
      */
     public function file_is_cached_after_checking_filesystem(): void


### PR DESCRIPTION
We were running into issues that on the first load it was giving us a miss even for subsequent calls.
What was happening was that when you retrieve something from cache that doesn't exist, it gets created but the cache item also gets saved to an array for some extra in memory caching. However, this would store the cache item with `->isHit() = false` making it so that each subsequent call for retrieving that cache item would still yield a `->isHit() = false` until you rerun the request where the array would be empty and it would retrieve the cache item from cache with `->isHit() = true`.

This PR removes the memory caching, we should leave the caching to the CacheItemPool.
I've also added a test to cover this case.

When adding the test, another error surfaced so I fixed a type-hint as well, though I'm not fully confident that it's fully covered now, I didn't have time to dive into that area.