### PR TITLE
Support PublicUrlGenerator and TemporaryUrlGenerator 

### DIFF
--- a/src/CacheAdapter.php
+++ b/src/CacheAdapter.php
@@ -12,15 +12,17 @@ use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCopyFile;
+use League\Flysystem\UnableToGeneratePublicUrl;
 use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToProvideChecksum;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToSetVisibility;
+use League\Flysystem\UrlGeneration\PublicUrlGenerator;
 use Psr\Cache\CacheItemPoolInterface;
 use RuntimeException;
 
-class CacheAdapter implements FilesystemAdapter, ChecksumProvider
+class CacheAdapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumProvider
 {
     use CacheItemsTrait;
     use CalculateChecksumFromStream;
@@ -477,5 +479,14 @@ class CacheAdapter implements FilesystemAdapter, ChecksumProvider
         $itemDestination->set($destinationStorageAttributes);
 
         $this->saveCacheItem($itemDestination);
+    }
+
+    public function publicUrl(string $path, Config $config): string
+    {
+        if (!$this->adapter instanceof PublicUrlGenerator) {
+            throw UnableToGeneratePublicUrl::noGeneratorConfigured($path);
+        }
+
+        return $this->adapter->publicUrl($path, $config);
     }
 }

--- a/src/CacheAdapter.php
+++ b/src/CacheAdapter.php
@@ -2,6 +2,7 @@
 
 namespace jgivoni\Flysystem\Cache;
 
+use DateTimeInterface;
 use ErrorException;
 use League\Flysystem\CalculateChecksumFromStream;
 use League\Flysystem\ChecksumAlgoIsNotSupported;
@@ -13,16 +14,18 @@ use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToCopyFile;
 use League\Flysystem\UnableToGeneratePublicUrl;
+use League\Flysystem\UnableToGenerateTemporaryUrl;
 use League\Flysystem\UnableToMoveFile;
 use League\Flysystem\UnableToProvideChecksum;
 use League\Flysystem\UnableToReadFile;
 use League\Flysystem\UnableToRetrieveMetadata;
 use League\Flysystem\UnableToSetVisibility;
 use League\Flysystem\UrlGeneration\PublicUrlGenerator;
+use League\Flysystem\UrlGeneration\TemporaryUrlGenerator;
 use Psr\Cache\CacheItemPoolInterface;
 use RuntimeException;
 
-class CacheAdapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumProvider
+class CacheAdapter implements FilesystemAdapter, PublicUrlGenerator, TemporaryUrlGenerator, ChecksumProvider
 {
     use CacheItemsTrait;
     use CalculateChecksumFromStream;
@@ -488,5 +491,14 @@ class CacheAdapter implements FilesystemAdapter, PublicUrlGenerator, ChecksumPro
         }
 
         return $this->adapter->publicUrl($path, $config);
+    }
+
+    public function temporaryUrl(string $path, DateTimeInterface $expiresAt, Config $config): string
+    {
+        if (!$this->adapter instanceof TemporaryUrlGenerator) {
+            throw UnableToGenerateTemporaryUrl::noGeneratorConfigured($path);
+        }
+
+        return $this->adapter->temporaryUrl($path, $expiresAt, $config);
     }
 }


### PR DESCRIPTION
Adds support for PublicUrlGenerator and TemporaryUrlGenerator of the wrapped FilesystemAdapter, so the default behavior can be kept when using CacheAdapter